### PR TITLE
Embed GEO label into metadata view for 2.8.x

### DIFF
--- a/present/metadata-iso19139.geoviqua.xsl
+++ b/present/metadata-iso19139.geoviqua.xsl
@@ -1353,9 +1353,11 @@
 					<div style="float:left;width:70%;">
 						<!-- geolabel -->
 						<div id="xhr_geolabel" style="position: relative; overflow: hidden; float: left; text-align: center; margin: 0 20px; width: 150px; height: 150px;">
-							<input name="xhr_metadata" id="xhr_metadata" type="hidden">
-								<xsl:attribute name="value"><xsl:value-of select="saxon:serialize(., 'serialize')" /></xsl:attribute>
-							</input>
+							<xsl:variable name="serialized_xml"><xsl:value-of select="saxon:serialize(., 'serialize')" /></xsl:variable>
+							<xsl:variable name="geonet_id"><xsl:value-of select="geonet:info/id" /></xsl:variable>
+							<xsl:variable name="geonet_uuid"><xsl:value-of select="geonet:info/uuid" /></xsl:variable>
+							<input name="xhr_metadata" id="xhr_metadata" type="hidden" value="{$serialized_xml}"/>
+							<input name="xhr_id" id="xhr_id" type="hidden" value="{$geonet_id}_{$geonet_uuid}"/>
 						</div>
 						<xsl:call-template name="iso19139.geoviqua-javascript"/>
 						<!-- thumbnail -->
@@ -4467,7 +4469,7 @@
 				else if (xhr.status === 200) {
 					container.innerHTML = json.data.label_svg;
 					if (sessionStorage) {
-						sessionStorage.setItem('geolabel', json.data.label_svg);
+						sessionStorage.setItem(key, json.data.label_svg);
 					}
 				}
 			};
@@ -4482,10 +4484,11 @@
 			xhr.send(params);
 		}
 
-		var container = document.getElementById('xhr_geolabel');
+		var container = document.getElementById('xhr_geolabel'),
+			key = 'geolabel_' + document.getElementById('xhr_id').value;
 
-		if (sessionStorage && sessionStorage.getItem('geolabel')) {
-			container.innerHTML = sessionStorage.getItem('geolabel');
+		if (sessionStorage && sessionStorage.getItem(key)) {
+			container.innerHTML = sessionStorage.getItem(key);
 		}
 		else {
 			requestGEOlabel();

--- a/present/metadata-iso19139.geoviqua.xsl
+++ b/present/metadata-iso19139.geoviqua.xsl
@@ -14,11 +14,14 @@
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:geonet="http://www.fao.org/geonetwork"
     xmlns:exslt="http://exslt.org/common"
+    xmlns:saxon="http://saxon.sf.net/"
     exclude-result-prefixes="gmx xsi gmd gco gml gts srv xlink exslt geonet gvq updated19115 gmd19157 un">
 
 	<xsl:include href="metadata-iso19139.geoviqua-fop.xsl"/>
 	<xsl:include href="metadata-iso19139.geoviqua-subtemplates.xsl"/>
 	<xsl:include href="metadata-iso19139.geoviqua-utils.xsl"/>
+
+	<xsl:output name="serialize" method="xml" omit-xml-declaration="no" indent="yes" saxon:indent-spaces="1"/>
 
 	<!-- ===================================================================== -->
 	<!-- code list processing -->
@@ -1343,11 +1346,19 @@
 
 		<xsl:variable name="dataset" select="gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue='dataset' or normalize-space(gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue)=''"/>
 
-		<!-- thumbnail -->
+		<!-- header -->
 		<tr>
 			<td valign="middle" colspan="2">
 				<xsl:if test="$currTab='metadata' or $currTab='identification' or /root/gui/config/metadata-tab/*[name(.)=$currTab]/@flat">
-					<div style="float:left;width:70%;text-align:center;">
+					<div style="float:left;width:70%;">
+						<!-- geolabel -->
+						<div id="xhr_geolabel" style="position: relative; overflow: hidden; float: left; text-align: center; margin: 0 20px; width: 150px; height: 150px;">
+							<input name="xhr_metadata" id="xhr_metadata" type="hidden">
+								<xsl:attribute name="value"><xsl:value-of select="saxon:serialize(., 'serialize')" /></xsl:attribute>
+							</input>
+						</div>
+						<xsl:call-template name="iso19139.geoviqua-javascript"/>
+						<!-- thumbnail -->
 						<xsl:variable name="md">
 							<xsl:apply-templates mode="brief" select="."/>
 						</xsl:variable>
@@ -4321,6 +4332,166 @@
 	<!-- match everything else and do nothing - leave that to iso19139 mode -->
 	<xsl:template mode="iso19139.geoviqua" match="*|@*"/>
 
-	<xsl:template name="iso19139.geoviqua-javascript"/>
+	<xsl:template name="iso19139.geoviqua-javascript">
+		<script type="text/javascript">
+		<![CDATA[
+		function createCORSRequest(method, url) {
+			var xhr = new XMLHttpRequest();
+			if ("withCredentials" in xhr) {
+
+				// Check if the XMLHttpRequest object has a "withCredentials" property.
+				// "withCredentials" only exists on XMLHTTPRequest2 objects.
+				xhr.open(method, url, true);
+			}
+			else if (typeof XDomainRequest != "undefined") {
+
+				// Otherwise, check if XDomainRequest.
+				// XDomainRequest only exists in IE, and is IE's way of making CORS requests.
+				xhr = new XDomainRequest();
+				xhr.open(method, url);
+			}
+			else {
+
+				// Otherwise, CORS is not supported by the browser.
+				xhr = null;
+			}
+			return xhr;
+		}
+
+		function requestGEOlabel() {
+
+			var xhr = createCORSRequest('POST', 'http://tutorial.geoviqua.org/geolabel.php?cors'),
+				params = "metadata=" + encodeURIComponent(document.getElementById('xhr_metadata').value) + "&size=150";
+
+			if (!xhr) {
+				container.innerHTML = "No GEO label available (your browser is not HTML5 compatible)";
+				return;
+			}
+
+			xhr.onloadstart = function() {
+				var preload = document.createElement('img');
+				preload.setAttribute('src', [
+				'data:image/gif;base64,R0lGODlhMgAyAKUAAAQCBISChMTCxERCRKSipOTi5CQiJGRmZJSSlNTS1LSytPTy9DQyNBQSFFRWVHx6fAwKDIyKjMz',
+				'KzExKTKyqrOzq7CwqLGxubJyanNza3Ly6vPz6/Dw6PBwaHFxeXAQGBISGhMTGxERGRKSmpOTm5CQmJGxqbJSWlNTW1LS2tPT29DQ2NBQWFFxaXHx+',
+				'fAwODIyOjMzOzExOTKyurOzu7CwuLHRydJyenNze3Ly+vPz+/Dw+PP///wAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQIBgAAACwAAAAAM',
+				'gAyAAAG/kCecEgsGnmbAKsRUB2f0Gj0BKgCTtKs9imzAmTbMHGDqHFmRpP3IG7fPtVPoogyVA2oYyKnaxsdXhFGJBgnJEcqJRAZfkUXXiNtOg8tC4',
+				'1EBStVDk5+fZdENDkhnaCmp6iplzo5FyAVqo0aEFUipbFEGSm3Qy1eMbhFGxYAN0dqVS+MwUM6Dh05Rxl2AA+fzEIqBVALGijX2OHi4+Tl5udbNBQ',
+				'C4OhCBcTVG+g6FK88EVYQNOgxtGwwrLzgdy7BCwA2eJDQ9AFEO3I5CBBUISCPu4sYM2rcqFFHBV4XVQBioWCcDgIucBxRYIUByFg5qkyYV2SElRIv',
+				'VbEEsINmYKgdHxoYE7cBhAdgiEIs48i0qVMtKTiImNNGxQkXh0yRYFGFw0MpIGSeynAQgAGfWw5UqXFqg9oPCI6QePAga5EEK2qUPKUiQYavE8Qiy',
+				'omLWgeOCF6wiLtRBw4cX8UEAQAh+QQIBgAAACwAAAAAMgAyAIUEAgSEhoREQkTExsQkJiTk5uSkpqRkYmQUEhTU1tS0trR0cnQ0NjT09vSUlpRUUl',
+				'QMCgzMzswsLizs7uysrqxsamwcGhzc3ty8vrx8enyMjoxMSkw8Pjz8/vykoqRcWlwEBgRERkTMyswsKizs6uysqqxkZmQUFhTc2ty8urx0dnQ8Ojz',
+				'8+vycmpxUVlQMDgzU0tQ0MjT08vS0srRsbmwcHhzk4uTEwsR8fnyUkpT///8AAAAAAAAAAAAAAAAAAAAG/kCdcEgsGoUUDqfEOjqfUOgNAgCAUtGs',
+				'1qmqVivHRmMbxXwOEWPOCwgUWQ5CrTIhH0VUwIlUJK2qDAVFKWwqdkY4bCVGDRgpMkY0bDFjh0MtbDd2AWwhTZZCMi4gLzQddiQSVSeaoEMsMCinh',
+				'yQeDiiuubq7vEYXLRSfvZYoNVUms8NGMrJHnFUINspGLA8grUUOXhaC00QdOCMJRxMCVg7eRh3C6ih86fDx8vP09fa9HQnd94zWCC38hEyAcWqGFw',
+				'KQ7nVgAIKCDgUHK9ljsaKhjgYfQCAwEFAHiQTJLtTpSLKkyZMo+a1DyUKDBQYw6EXwMLJIAhBVNsyz8QKAbYkjEbxwmHcTgItkrw68sIBFXocSGS4',
+				'46YBiX8qrWLM6uZBBQ0I7HW4YkOiKRYwqCyxRwEljFwkEVQQg1bIGgM5dCwC84Lgsh4Z3RQq4EDCAF4sENuYKyQvggBMW7OJtqDL0pAgJEjCkbBAZ',
+				'VBAAIfkECAYAAAAsAAAAADIAMgCFBAIEhIKExMLEREJEJCIkpKKk5OLkZGJkFBIUlJKU1NLUVFJUNDI0tLK09PL0dHZ0DAoMjIqMzMrMTEpMLCosr',
+				'Kqs7OrsbGpsHBocnJqc3NrcXFpcPDo8vLq8/Pr8fH58BAYEhIaExMbEREZEJCYkpKak5ObkZGZkFBYUlJaU1NbUVFZUNDY0tLa09Pb0fHp8DA4MjI',
+				'6MzM7MTE5MLC4srK6s7O7sbG5sHB4cnJ6c3N7cXF5cPD48vL68/P78////Bv7An3BILBqFitNJcmw6n1AdBgBAqKDYbDNHpca04KLmEzEZG11Awdg',
+				'bcRKesNGAozJcRc+OusATVTBdOXJFJWlMeSoycUUJaTM+hEMdaQZhNWknkkM+Dxg4KXIuM1QUOptDHiYWki4CLWaosrO0Wj6MRw49MrVPAjMcLw5G',
+				'NjwAEF+9RhpTVBdGFV0kw8pEKWkYNkUtXTR+1UIFaQTfQi4nABgd4EQmNF3JRi647EI2ITctkfX8/f7/AAOGmSewiYcHMAj0KGgulgIQVAbQA7gDA',
+				'6+HESf+O2Dxh4cPMEiIYPjDQSwhHjSSXMmypcuXMP/5qDHhAbV+LiwdMYCASmQEfz5mYGhxRAVEAA/8eXg3yMhBBDQ0/NPRQ6UQE+Viat3KdYiNGB',
+				'myajEgY5+sDVQ+EFIQKAMtBlR2EEID4AatGiQYIMrTooHYHy4e7DhFy8HNIikghnj5gMqBlwZmjJDadVMQACH5BAgGAAAALAAAAAAyADIAhQQCBIS',
+				'ChMTCxERGROTi5CQiJKSipGRmZBQSFNTS1PTy9JSSlFxaXDQyNLSytHR2dAwKDIyKjMzKzExOTOzq7CwqLGxubBwaHNza3Pz6/Ly6vKyqrJyanGRi',
+				'ZDw+PHx+fAQGBISGhMTGxExKTOTm5CQmJKSmpGxqbBQWFNTW1PT29JSWlFxeXDQ2NLS2tHx6fAwODIyOjMzOzFRSVOzu7CwuLHRydBweHNze3Pz+/',
+				'Ly+vP///wAAAAAAAAAAAAAAAAb+wJ1wSCwahaRFjHBsOp9QVQMAqNCg2GxTR6U6tOAibeNQGRMgKkhkxFg6uvBR5aGycsYADPbKFBU3VBBsckQCXQ',
+				'BXRTk0NH5FLog2hUQpMFQIZmAJiBGURCslDS5yORYQAAOKn0IKmnIZKTKvrLW2t7Y5GBS4TwQPDCaPRBkdMBcavUc0U1QrRhJdHspGkV0NRilpACP',
+				'URVzSRjkRFy0p3kQKE2pfRznD6EIqBiEJ8ff4+fr7/P22ODZmCMvBoQIDEv4IBKISwBKVF/5WIEKB4RIAiP0WILqQIcaNEQj74bjQBaM/IglYDFgB',
+				'76TLlzBjypSZ4EQIWvHeNVHRggphh3w5XtQ4Z0RBAYb5MkyAEOfIhhITVt2jgaHlzKtYs7LK4EIAnkIZrFIKQMVEIRUMGuC4xYDKh0IEUAAgZUuEh',
+				'xFrj6RI8LWaAZyfVIjdoQMGhHYxJQLwJJPGiQO8tNYKAgAh+QQIBgAAACwAAAAAMgAyAIUEAgSEgoTEwsREQkQkIiSkoqTk4uRkZmQUEhSUkpTU0t',
+				'Q0MjS0srT08vRUUlR0dnQMCgyMiozMyswsKiysqqzs6uxsbmwcGhycmpzc2tw8Ojy8urz8+vxcWlxMSkx8fnwEBgSEhoTExsRERkQkJiSkpqTk5uR',
+				'samwUFhSUlpTU1tQ0NjS0trT09vRUVlR8enwMDgyMjozMzswsLiysrqzs7ux0cnQcHhycnpzc3tw8Pjy8vrz8/vxcXlz///8AAAAG/kCfcEgsGoWt',
+				'DatxbDqfUJ4LAHDwoNhsMwOiglTacJEjy3CMJhgVYjLWMJGc+Mg7AECxI45wwxg5A1Q3BnNFKmoAN1dGDUxGKlRUfoVDFShUK2dhJl1UNJRELBojC',
+				'oUJFzAHmqCsQyY5i62ys7SsNbG1jDgBMkccNigacrljDlQwO4+dL8RFCp0ALkYGEFR5zUMq1VQHfyUDFo7YPhwWVCi9dONjOyVt6/Dx8vP09fZaDS',
+				'm8QhIOD+LzGmhYQ6PFDGv2WEQCMKABCSoh7DFYqMPHjgEHKtircfBOgXtFTASwwAKkyZMoU6pcVyPGgx24KiVgEJNYhQWRUvwxBkIAZzwcC0msQqK',
+				'DCgV4MRZeAChEgAcLLeCpuMQtpYARM17UUMkh6sqvrHhkeEepJiUKABCkE8PjQw+mlB5QKVGoxQQAGWblcHAArhAOZoXI2BB4DuAmFTTo0JhSBggQ',
+				'pVLyYECjMNgwQQAAIfkECAYAAAAsAAAAADIAMgCFBAIEhIKEREJExMLEJCIk5OLkpKKkZGJkFBIU1NLUNDI09PL0tLK0dHJ0lJKUVFJUDAoMTEpMz',
+				'MrMLCos7OrsrKqsbGpsHBoc3NrcPDo8/Pr8vLq8fHp8nJqcjIqMXFpcBAYEREZExMbEJCYk5ObkpKakZGZkFBYU1NbUNDY09Pb0tLa0dHZ0lJaUVF',
+				'ZUDA4MTE5MzM7MLC4s7O7srK6sbG5sHB4c3N7cPD48/P78vL68fH58nJ6cjI6M////AAAABv5An3BILBqFuQQqd2w6n1Df7gUJRK9Y4wICALxU2fB',
+				'QcyMdVbauTWPU6BgzsTFXAyBWxw0ONziaugJgckMFCF0wTRpsWl1dOoNDKhNdLGIqJ10gCZBDKDUeC3IMEyM9nKdEKnGorK2ur7A+OToVZkcMKQer',
+				'sUgsIAAjN0YzaQAOvISYXVZFC5MAHchCJBeNpkYDLjuC0j1dCrbSUTcii+Ln6Onq6+ztRRorPLY3HAbm6SofXRcJOSFdeNYlaASghgYcXWiwi0HQg',
+				'g8UB3pww/fPjgh3RBbw8IACo8ePIEOKdKWBAQ9hZzZsEqcCRpcXfYw0AHAiHK8NBCPMcdFlJV8yGgQzHMFgogUTaSRGNGoBEiKMDvc8Hh3JjkKJk6',
+				'00TM1CQYaaGKhuyPgw8UoAgg+2iqJZQMyfRimiWuIRMAwDgjvOqThgoqwPDQFsXDARSlyBExcoNFGlTgJYqqyCAAAh+QQIBgAAACwAAAAAMgAyAIU',
+				'EAgSEgoTEwsREQkQkIiSkoqTk4uRkYmQUEhSUkpTU0tQ0MjS0srT08vR0cnRUVlQMCgyMiozMyswsKiysqqzs6uxsamwcGhycmpzc2tw8Ojy8urz8',
+				'+vxMSkx8enxcXlwEBgSEhoTExsRERkQkJiSkpqTk5uRkZmQUFhSUlpTU1tQ0NjS0trT09vRcWlwMDgyMjozMzswsLiysrqzs7uxsbmwcHhycnpzc3',
+				'tw8Pjy8vrz8/vx8fnz///8AAAAAAAAG/sCecEgsGoW7jOHIbDqfQhgCVYBar0cUADDBeouNFnOwfRw5GQXne6SQcpmjwcGrHCMgQG3NHu5IWzVfHF',
+				'oALzh9RGQAEV87MlsXNIlDJjwpYl8xIxoblJ+goaKjpKVNGSKZRhIuEXymQykvICMNRi0rW56wQjSAWzNGHIsivEItE1sALEcZHiU7xkIzLwAfqtJ',
+				'OLRXR2d7f4OHi4+MKOpk0NwLjOzwQIBp2FgAIKuIVEMopPR8AEAriTOTZkqCHiRAMuoHjUGOLDBPkiHDQMWNSxIsYM2rcKGqHgg3Yiph4xYuDgy0k',
+				'EBlhceEDSVMKBgJwcCQFgAUvS4mQeeBIaAsWKo01yLEFgo6MFULUEKCQo1NwLQQIsAiqKZYWHbZogPiJxoMQOZ/cUAbAAygFAGSExZECA1ciAch+q',
+				'LoBoBEFF7bYCCpkp7IS0vopE1SEwgoZKcKOGkHWzMUEZG9gbOHAhg1Xn4IAACH5BAgGAAAALAAAAAAyADIAhQQCBISChMTCxERCRCQiJOTi5KSipG',
+				'RiZBQSFJSSlNTS1DQyNPTy9LSytHRydFRSVAwKDIyKjMzKzCwqLOzq7GxqbBwaHJyanNza3Dw6PPz6/Ly6vExKTKyqrHx6fAQGBISGhMTGxERGRCQ',
+				'mJOTm5KSmpGRmZBQWFJSWlNTW1DQ2NPT29LS2tHR2dFxaXAwODIyOjMzOzCwuLOzu7GxubBweHJyenNze3Dw+PPz+/Ly+vP///wAAAAAAAAAAAAAA',
+				'AAb+wJ1wSCwahyvNcclsOoU6mUrxrFqPOADgce0WNcqjS9s65gqYsLcYwrkoR1IANjuWIB/P2jjQorwaWQAnDHtENAAfLGsVWipqhislApBWDCAtB',
+				'YabnJ2en6ChXhQ3OUs3Hg2iRywWLxWVOzkPiZqrQxoqWgApRhpjLyS3Qzl9iTdHMwYSw0QSMhYwps1VOdPU2Nna29zd3sm2Oxopdd42CB8HKzsdHw',
+				'PeDDW7OjslADjwFvPiCnDeKC8+uFj3jQiJFLEKKlzIsKHDTaQSCgGTLcEHABzKFYkxAQS2Aid22TiyQeC1Wzde7IpwRAOGQtQ0HNBSI1xBSReQPdy',
+				'5JgVoihL+uoxD2ElHSAALNFar8ALCwE0ajGlJ0EXHLgAGNq2YcFVPkRksdMAkYuMqy02IdgkoQkKGFhxjhYDU8iIGpxkmLIxAcXKHh6t/NrpwQc8T',
+				'A4JFZu7yWrDBRQAQQizUYCMDDlWcggAAIfkECAYAAAAsAAAAADIAMgCFBAIEhIKExMLEREJEpKKk5OLkJCIkZGJkFBIUlJKU1NLUVFJUtLK09PL0N',
+				'DI0dHJ0DAoMjIqMzMrMTEpMrKqs7OrsHBocnJqc3NrcXFpcvLq8/Pr8PDo8fHp8LCosbGpsBAYEhIaExMbEREZEpKak5ObkJCYkZGZkFBYUlJaU1N',
+				'bUVFZUtLa09Pb0NDY0dHZ0DA4MjI6MzM7MTE5MrK6s7O7sHB4cnJ6c3N7cXF5cvL68/P78PD48fH58////AAAABv5An3BILBqPyKRyeVSMFgWmdHr',
+				'MAAAdqpbau96QrdYWicn0xMYWjbU5Chwe1th4uurGiytvXowBECpjL1cnfEQbMiVzDSkpDYaQkZKTlJWWSS2KSBsaOJdGKh4oL21GCQAupZ9CdVdR',
+				'RjQWGTurQwFXCJpGJWi1PjUfM3K+xMXGx8jJystaO70+JY/KGgYwIbQSKB/KLRxXMBg+2dvJLS7f4dDPxxo21qrMPs7x9PX29587DB8hNcUb62xdA',
+				'eDAXy0GKEA8WFfDxkAAFGrVMDHwDpEKKB5+WVXDwEAGRg4MtPFqVQgIAHhII1LjhYsFMorJ0BFwyAZ4+HJepCGgJmCTCiVoQVJBEcAKnEwi2LDQQe',
+				'icHTkeDpuCYSAIEYY2jHh4IY0CDEh1PKQB6dQ3T0QaTAAA4gDOFkUN6JrTIoaLEQKM3HhokUiJEAHQ1ro1kAQ9GTCuWJi7TECODzEhBQEAIfkECAY',
+				'AAAAsAAAAADIAMgCFBAIEhIaExMbEREJEpKak5ObkZGJkJCIkFBIUlJaU1NbUdHJ0VFJUvLq89Pb0NDI0DAoMjI6MzM7MrK6s7O7sbGpsHBocnJ6c',
+				'3N7cfHp8XFpcTEpMLCosxMLE/P78PD48BAYEjIqMzMrMREZErKqs7OrsZGZkFBYUnJqc3NrcdHZ0VFZUvL68/Pr8NDY0DA4MlJKU1NLUtLK09PL0b',
+				'G5sHB4cpKKk5OLkfH58XF5cLC4s////AAAAAAAAAAAAAAAABv7AnXBILBqPyKRyeSwYFhSmdHrEAQAXqpZKgCA6SEdrG740kJ6YApkafWJk4wRgKZ',
+				'BV11y8mNJpHGQ2VyF7RS0ecS0sLGOFjo+QkZKTlHEeKVGVRTcbOhNIDSAaiJpDGVccgEYSHAGlRDBXH6pGja9CMwEVa7e9vr/AwcLDSy0JIyYpxEQ',
+				'LVwA1dsEYIxYJHi/OACjCNFcIGAjZWcF4ACc3p1c1JcI3DDpZDigMNBjL9/j5+vuvEiEEtl4dQkICxBUGtDRJeFADBikiD7IJeOXhwxUQ9oh4OJCN',
+				'hUAXF+EUiWAQwIdMpWSceEEjoJAWNjSoiHarBAaX/HJOmSEhBVtOKQ4S7ilh8UUGMhNccBhXyIozXjuxAXiRcU+FbGCKeChB4eGQAs5AiHAUCpXQF',
+				'jReIHBlaMWVEUK3eGiQQ0XVIWUBQIA6xIGMCTN6EZCIrwRHk3HbJUDBzlEQACH5BAgGAAAALAAAAAAyADIAhQQCBISChMTCxERCROTi5CQiJKSipG',
+				'RiZBQSFNTS1PTy9LSytHRydJSSlFRSVDQyNAwKDMzKzExKTOzq7KyqrGxqbBwaHNza3Pz6/Ly6vHx6fJyanDw6PIyKjCwqLFxaXAQGBISGhMTGxER',
+				'GROTm5KSmpGRmZBQWFNTW1PT29LS2tHR2dJSWlDQ2NAwODMzOzExOTOzu7KyurGxubBweHNze3Pz+/Ly+vHx+fJyenDw+PCwuLFxeXP///wAAAAAA',
+				'AAb+wJ5wSCwaj8ikcnnElBY2pnR6jIBAKKqWSmoNYknMFmm7ZZFiZOzwIYyNCdAuNd4AALh3MfYJRbciLiAyekV/bwQ1hYuMjY5DGGmPYzEMOyMCk',
+				'2MHdwAnippEChUwEUYxJ50AG6FEBncDkkIpBaolrUMZdzyHQw2dLWC4PRgyLBNHNhkrHQrDz9DR0tPU1WQZMx3C1kMbIHcPztQkBwM3PQ+qGdU4dz',
+				'sYHKqZ1O0ALSklEHc6dNQxKw4SCImAI0c/bggTKlzIUBqJEgJ6DZNFJAKCOyskaopRYYAMij0+dEIACleAOy5IGHHQCcIZXAzugCg5RIWLOx9ATrr',
+				'w4IRoBp0RAhiMhmFbw6NvMNRQuTAFDwQWWG15MULHuUUlWhplYsPDHRpbt7BQ5caIgoNEMFwE4KKsngsW7ozQyKKAh1tGQnyr0OhCiBziiNS4CQBB',
+				'WAwoEuicZEWmW24YJOxiqGCBCrRvggAAIfkECAYAAAAsAAAAADIAMgCFBAIEhIaEREJExMbEJCIkrKqsZGJk5ObkFBIUlJaU1NbUNDI0dHJ0VFJUv',
+				'Lq89Pb0DAoMjI6MTEpMzM7MLCostLK0bGps7O7sHBocnJ6c3N7cPDo8fHp8XFpcxMLE/P78BAYEjIqMREZEzMrMJCYkrK6sZGZk7OrsFBYUnJqc3N',
+				'rcNDY0dHZ0vL68/Pr8DA4MlJKUTE5M1NLULC4stLa0bG5s9PL0HB4cpKKk5OLkPD48fH58XF5c////AAAAAAAABv7AnnBILBqPyKRyiRxNmFDm5YH',
+				'MoW6nqLZ4MWEIEZfxYTBRt2gWYA2ooD+l1Bk9dC3YgBpagwC06EQuInghaDYNKzmARAMYawsXdB9ii0QaKTiRlZucmx+dnC4JMQYqoIshbBRZp0Yu',
+				'ERamRjN4NK1GI2sdRzp4HrdFGi8AO0cOEGsNc8BCMi3Llik0lMzV1tfY2drbnDIBODbcRy19ADHU2g8BpT08eAriBWsiPQZ4stslIAANPROOAHh84',
+				'vYAxw5FPQ4UaIFOnMOHECNKnNjjwQANFA9QWAMD2wMODUYcCcAGyzUYa2ZA68GBDYYD11IBIBGuiIobAEAUu3ahw2UKB0gO4PAwkKLRo0xs1JwYgM',
+				'AMoGguBKiBb9EIZAAwNGRSI+XWLTTYgFjZw8XXD4MAoGC1yMaGNXqMONAh4JeREsNYdLpQguEYgASK1jmg4WurC8MAvCDLjQMECAEoulCgQDCgIAA7'
+				].join(''));
+				preload.setAttribute('alt', 'Requesting GEO label...');
+				preload.style.cssText = 'position: absolute; top: 50%; left: 50%; margin-left: -25px; margin-top: -25px;';
+				container.appendChild(preload);
+			}
+
+			xhr.onload = function() {
+				var json = JSON.parse(xhr.responseText);
+
+				if (xhr.status === 500 || json.status === "error") {
+					container.innerHTML = "Error: " + json.message;
+				}
+				else if (xhr.status === 200) {
+					container.innerHTML = json.data.label_svg;
+					if (sessionStorage) {
+						sessionStorage.setItem('geolabel', json.data.label_svg);
+					}
+				}
+			};
+
+			xhr.onerror = function() {
+				container.innerHTML = "No GEO label available (could not connect to the GEO label proxy service)";
+			};
+
+			xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+			xhr.setRequestHeader("Content-length", params.length);
+			xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+			xhr.send(params);
+		}
+
+		var container = document.getElementById('xhr_geolabel');
+
+		if (sessionStorage && sessionStorage.getItem('geolabel')) {
+			container.innerHTML = sessionStorage.getItem('geolabel');
+		}
+		else {
+			requestGEOlabel();
+		}
+		]]>
+		</script>
+	</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This feature was developed as part of the 2.10.x-dev branch (69b046ceffcacb8ed81e7e34b96a6e3ffac3d5f4, 54bcaf7cd2b601dbd7a4787fb46d26c81a843915, 181b95fec3101749ac5b2d40b7a7d09d937ecb64) to embed GEO labels into the metadata view for GVQ documents.

The XHR to call the GEO label API is to a proxy script that allows cross-origin resource sharing (GeoViQua/geoviqua-tutorial#2)
